### PR TITLE
fix: Fix grid AOI silent failure on same-scene startup and add degraded fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.cursorj/
+.idea/

--- a/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
+++ b/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
@@ -1,3 +1,4 @@
+// CE scalability: #41
 using Insthync.SpatialPartitioningSystems;
 using LiteNetLibManager;
 using System.Collections.Generic;

--- a/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
+++ b/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
@@ -23,7 +23,12 @@ namespace MultiplayerARPG
         private Bounds _bounds;
         private List<SpatialObject> _spatialObjects = new List<SpatialObject>();
         private Dictionary<uint, HashSet<uint>> _playerSubscribings = new Dictionary<uint, HashSet<uint>>();
+        private readonly Queue<HashSet<uint>> _hashSetPool = new Queue<HashSet<uint>>();
+        private readonly HashSet<uint> _fallbackSubscribings = new HashSet<uint>();
         private HashSet<uint> _alwaysVisibleObjects = new HashSet<uint>();
+        private bool _didLogMissingSystemWarning;
+
+        public bool IsSystemReady => _system != null;
 
         private void OnDrawGizmosSelected()
         {
@@ -35,6 +40,14 @@ namespace MultiplayerARPG
 
         private void OnDestroy()
         {
+            ReleaseSystem();
+        }
+
+        private void ReleaseSystem()
+        {
+            if (_system == null)
+                return;
+            _system.Dispose();
             _system = null;
         }
 
@@ -50,9 +63,14 @@ namespace MultiplayerARPG
         {
             if (!IsServer || !isOnline)
             {
-                _system = null;
+                ReleaseSystem();
+                _didLogMissingSystemWarning = false;
                 return;
             }
+            // Full online scene load is already handled by OnServerOnlineSceneLoaded().
+            // Keep this callback for additive scene changes that can alter AOI bounds.
+            if (!isAdditive)
+                return;
             PrepareSystem();
         }
 
@@ -60,10 +78,11 @@ namespace MultiplayerARPG
         {
             if (!IsServer || !Manager.ServerSceneInfo.HasValue)
             {
-                _system = null;
+                ReleaseSystem();
+                _didLogMissingSystemWarning = false;
                 return;
             }
-            _system = null;
+            ReleaseSystem();
             var mapBounds = GenericUtils.GetComponentsFromAllLoadedScenes<AOIMapBounds>(true);
             if (mapBounds.Count > 0)
             {
@@ -115,6 +134,21 @@ namespace MultiplayerARPG
                         break;
                 }
             }
+
+            if (_system == null && IsServer && Manager.ServerSceneInfo.HasValue)
+            {
+                if (!_didLogMissingSystemWarning)
+                {
+                    Debug.LogWarning("[AOI] PrepareSystem: No AOIMapBounds or scene colliders found. " +
+                        "Grid AOI system could not initialize. Interest management will run in degraded " +
+                        "fallback mode (O(N*M) range checks). Add an AOIMapBounds component to your map scene.");
+                    _didLogMissingSystemWarning = true;
+                }
+            }
+            else
+            {
+                _didLogMissingSystemWarning = false;
+            }
         }
 
         public override void UpdateInterestManagementImmediate()
@@ -126,12 +160,22 @@ namespace MultiplayerARPG
         public override void UpdateInterestManagement(float deltaTime)
         {
             if (_system == null)
+            {
+                FallbackUpdateInterestManagement(deltaTime);
                 return;
+            }
 
             _updateCountDown -= deltaTime;
             if (_updateCountDown > 0)
                 return;
             _updateCountDown = updateInterval;
+
+            foreach (KeyValuePair<uint, HashSet<uint>> kv in _playerSubscribings)
+            {
+                kv.Value.Clear();
+                _hashSetPool.Enqueue(kv.Value);
+            }
+            _playerSubscribings.Clear();
 
             using (s_UpdateProfilerMarker.Auto())
             {
@@ -179,7 +223,7 @@ namespace MultiplayerARPG
                             continue;
                         }
                         if (!_playerSubscribings.TryGetValue(contactedObjectId, out subscribings))
-                            subscribings = new HashSet<uint>();
+                            subscribings = _hashSetPool.Count > 0 ? _hashSetPool.Dequeue() : new HashSet<uint>();
                         subscribings.Add(spawnedObject.ObjectId);
                         _playerSubscribings[contactedObjectId] = subscribings;
                     }
@@ -230,7 +274,6 @@ namespace MultiplayerARPG
                                 }
                             }
                             playerObject.UpdateSubscribings(subscribings);
-                            subscribings.Clear();
                         }
                         else if (_alwaysVisibleObjects.Count > 0)
                         {
@@ -242,6 +285,97 @@ namespace MultiplayerARPG
                         }
                     }
                 }
+            }
+        }
+
+        private void FallbackUpdateInterestManagement(float deltaTime)
+        {
+            _updateCountDown -= deltaTime;
+            if (_updateCountDown > 0)
+                return;
+            _updateCountDown = updateInterval;
+
+            foreach (LiteNetLibPlayer player in Manager.GetPlayers())
+            {
+                if (!player.IsReady)
+                    continue;
+                foreach (LiteNetLibIdentity playerObject in player.GetSpawnedObjects())
+                {
+                    _fallbackSubscribings.Clear();
+                    foreach (LiteNetLibIdentity spawnedObject in Manager.Assets.GetSpawnedObjects())
+                    {
+                        if (ShouldSubscribe(playerObject, spawnedObject))
+                            _fallbackSubscribings.Add(spawnedObject.ObjectId);
+                    }
+                    playerObject.UpdateSubscribings(_fallbackSubscribings);
+                }
+            }
+
+            foreach (ISpatialObjectComponent component in SpatialObjectContainer.GetValues())
+            {
+                if (component == null)
+                    continue;
+                component.ClearSubscribers();
+                if (!component.SpatialObjectEnabled)
+                    continue;
+                foreach (LiteNetLibPlayer player in Manager.GetPlayers())
+                {
+                    if (!player.IsReady)
+                        continue;
+                    foreach (LiteNetLibIdentity playerObject in player.GetSpawnedObjects())
+                    {
+                        if (IsWithinSpatialShape(playerObject.transform.position, component))
+                        {
+                            component.AddSubscriber(playerObject.ObjectId);
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool IsWithinSpatialShape(Vector3 objectPosition, ISpatialObjectComponent component)
+        {
+            switch (component.SpatialObjectShape)
+            {
+                case SpatialObjectShape.Box:
+                    return IsWithinBox(
+                        objectPosition,
+                        (Vector3)component.SpatialObjectPosition,
+                        (Vector3)component.SpatialObjectExtents);
+                default:
+                    return IsWithinSphere(
+                        objectPosition,
+                        (Vector3)component.SpatialObjectPosition,
+                        component.SpatialObjectRadius);
+            }
+        }
+
+        private bool IsWithinBox(Vector3 objectPosition, Vector3 center, Vector3 extents)
+        {
+            switch (GameInstance.Singleton.DimensionType)
+            {
+                case DimensionType.Dimension2D:
+                    return Mathf.Abs(objectPosition.x - center.x) <= extents.x &&
+                        Mathf.Abs(objectPosition.y - center.y) <= extents.y;
+                default:
+                    return Mathf.Abs(objectPosition.x - center.x) <= extents.x &&
+                        Mathf.Abs(objectPosition.z - center.z) <= extents.z;
+            }
+        }
+
+        private bool IsWithinSphere(Vector3 objectPosition, Vector3 center, float radius)
+        {
+            float radiusSqr = radius * radius;
+            switch (GameInstance.Singleton.DimensionType)
+            {
+                case DimensionType.Dimension2D:
+                    float xDiff2D = objectPosition.x - center.x;
+                    float yDiff2D = objectPosition.y - center.y;
+                    return xDiff2D * xDiff2D + yDiff2D * yDiff2D <= radiusSqr;
+                default:
+                    float xDiff3D = objectPosition.x - center.x;
+                    float zDiff3D = objectPosition.z - center.z;
+                    return xDiff3D * xDiff3D + zDiff3D * zDiff3D <= radiusSqr;
             }
         }
     }

--- a/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
+++ b/Core/Scripts/Networking/AOI/JobifiedGridSpatialPartitioningAOI.cs
@@ -335,24 +335,34 @@ namespace MultiplayerARPG
 
         private bool IsWithinSpatialShape(Vector3 objectPosition, ISpatialObjectComponent component)
         {
+            return IsWithinSpatialShape(
+                objectPosition,
+                component,
+                GameInstance.Singleton.DimensionType);
+        }
+
+        private static bool IsWithinSpatialShape(Vector3 objectPosition, ISpatialObjectComponent component, DimensionType dimensionType)
+        {
             switch (component.SpatialObjectShape)
             {
                 case SpatialObjectShape.Box:
                     return IsWithinBox(
                         objectPosition,
                         (Vector3)component.SpatialObjectPosition,
-                        (Vector3)component.SpatialObjectExtents);
+                        (Vector3)component.SpatialObjectExtents,
+                        dimensionType);
                 default:
                     return IsWithinSphere(
                         objectPosition,
                         (Vector3)component.SpatialObjectPosition,
-                        component.SpatialObjectRadius);
+                        component.SpatialObjectRadius,
+                        dimensionType);
             }
         }
 
-        private bool IsWithinBox(Vector3 objectPosition, Vector3 center, Vector3 extents)
+        private static bool IsWithinBox(Vector3 objectPosition, Vector3 center, Vector3 extents, DimensionType dimensionType)
         {
-            switch (GameInstance.Singleton.DimensionType)
+            switch (dimensionType)
             {
                 case DimensionType.Dimension2D:
                     return Mathf.Abs(objectPosition.x - center.x) <= extents.x &&
@@ -363,10 +373,10 @@ namespace MultiplayerARPG
             }
         }
 
-        private bool IsWithinSphere(Vector3 objectPosition, Vector3 center, float radius)
+        private static bool IsWithinSphere(Vector3 objectPosition, Vector3 center, float radius, DimensionType dimensionType)
         {
             float radiusSqr = radius * radius;
-            switch (GameInstance.Singleton.DimensionType)
+            switch (dimensionType)
             {
                 case DimensionType.Dimension2D:
                     float xDiff2D = objectPosition.x - center.x;

--- a/Core/Scripts/Networking/BaseGameNetworkManager.cs
+++ b/Core/Scripts/Networking/BaseGameNetworkManager.cs
@@ -1,4 +1,5 @@
-﻿using ConcurrentCollections;
+﻿// CE scalability: #41
+using ConcurrentCollections;
 using Cysharp.Threading.Tasks;
 using Insthync.AddressableAssetTools;
 using Insthync.DevExtension;

--- a/Core/Scripts/Networking/BaseGameNetworkManager.cs
+++ b/Core/Scripts/Networking/BaseGameNetworkManager.cs
@@ -989,6 +989,22 @@ namespace MultiplayerARPG
             {
                 component.OnServerOnlineSceneLoaded(this);
             }
+
+            if (InterestManager is JobifiedGridSpatialPartitioningAOI gridAOI)
+            {
+                gridAOI.PrepareSystem();
+                if (gridAOI.IsSystemReady)
+                    Logging.Log(LogTag, "[AOI] Grid spatial partitioning system initialized successfully.");
+                else
+                    Logging.LogWarning(LogTag, "[AOI] Grid AOI system not initialized after PrepareSystem. " +
+                        "Running in degraded fallback mode. Add AOIMapBounds to your scene.");
+            }
+            else if (InterestManager is DefaultInterestManager)
+            {
+                Logging.LogWarning(LogTag, "[AOI] Using DefaultInterestManager (O(N*M) brute force). " +
+                    "This will not scale. Ensure JobifiedGridSpatialPartitioningAOI is configured.");
+            }
+
             _serverSceneLoadedTime = Time.unscaledTime;
             _serverReadyToInstantiateObjectsStates.Clear();
             _isServerReadyToInstantiateObjects = false;

--- a/Core/Tests.meta
+++ b/Core/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d2f483518a64c2caf45844e74288a47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Core/Tests/EditMode.meta
+++ b/Core/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5dbfcb271ae4b9d9df5313ea6a2e2d1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Core/Tests/EditMode/JobifiedGridSpatialPartitioningAOITests.cs
+++ b/Core/Tests/EditMode/JobifiedGridSpatialPartitioningAOITests.cs
@@ -1,0 +1,262 @@
+using Insthync.SpatialPartitioningSystems;
+using LiteNetLibManager;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace MultiplayerARPG.Tests.EditMode
+{
+    [TestFixture]
+    public class JobifiedGridSpatialPartitioningAOITests
+    {
+        private readonly List<GameObject> _createdObjects = new List<GameObject>();
+        private GameInstance _previousGameInstance;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _previousGameInstance = GameInstance.Singleton;
+            SetGameInstanceSingleton(null);
+            SetGameInstanceSingleton(CreateGameInstance(DimensionType.Dimension3D));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SetGameInstanceSingleton(_previousGameInstance);
+            for (int i = _createdObjects.Count - 1; i >= 0; --i)
+            {
+                if (_createdObjects[i] != null)
+                    UnityEngine.Object.DestroyImmediate(_createdObjects[i]);
+            }
+            _createdObjects.Clear();
+        }
+
+        [Test]
+        public void PrepareSystem_CreatesSystem_WhenColliderExists()
+        {
+            (JobifiedGridSpatialPartitioningAOI aoi, _) = CreateAoiWithManager(
+                true,
+                new ServerSceneInfo
+                {
+                    isAddressable = false,
+                    sceneName = "TestScene",
+                });
+            CreateColliderObject();
+
+            aoi.PrepareSystem();
+
+            Assert.That(aoi.IsSystemReady, Is.True);
+        }
+
+        [Test]
+        public void PrepareSystem_DisposesExistingSystem_WhenSceneInfoMissing()
+        {
+            (JobifiedGridSpatialPartitioningAOI aoi, LiteNetLibGameManager manager) = CreateAoiWithManager(
+                true,
+                new ServerSceneInfo
+                {
+                    isAddressable = false,
+                    sceneName = "TestScene",
+                });
+            CreateColliderObject();
+            aoi.PrepareSystem();
+            JobifiedGridSpatialPartitioningSystem oldSystem = GetPrivateField<JobifiedGridSpatialPartitioningSystem>(aoi, "_system");
+
+            SetAutoPropertyBackingField(
+                manager,
+                typeof(LiteNetLibGameManager),
+                "ServerSceneInfo",
+                (ServerSceneInfo?)null);
+            aoi.PrepareSystem();
+
+            Assert.That(aoi.IsSystemReady, Is.False);
+            Assert.That(IsCellToObjectsCreated(oldSystem), Is.False);
+        }
+
+        [Test]
+        public void OnLoadSceneFinish_ReinitializesOnlyForAdditiveOnlineLoads()
+        {
+            (JobifiedGridSpatialPartitioningAOI aoi, _) = CreateAoiWithManager(
+                true,
+                new ServerSceneInfo
+                {
+                    isAddressable = false,
+                    sceneName = "TestScene",
+                });
+            GameObject colliderObject = CreateColliderObject();
+            aoi.PrepareSystem();
+            Assert.That(aoi.IsSystemReady, Is.True);
+            UnityEngine.Object.DestroyImmediate(colliderObject);
+
+            InvokeOnLoadSceneFinish(aoi, false, true);
+            Assert.That(aoi.IsSystemReady, Is.True, "Non-additive load should not reinitialize grid AOI.");
+
+            InvokeOnLoadSceneFinish(aoi, true, true);
+            Assert.That(aoi.IsSystemReady, Is.False, "Additive online load should reinitialize AOI and reflect missing bounds.");
+        }
+
+        [Test]
+        public void PrepareSystem_MissingSystemWarningFlag_DeduplicatesAndResets()
+        {
+            (JobifiedGridSpatialPartitioningAOI aoi, _) = CreateAoiWithManager(
+                true,
+                new ServerSceneInfo
+                {
+                    isAddressable = false,
+                    sceneName = "TestScene",
+                });
+
+            aoi.PrepareSystem();
+            Assert.That(aoi.IsSystemReady, Is.False);
+            Assert.That(GetPrivateField<bool>(aoi, "_didLogMissingSystemWarning"), Is.True);
+
+            aoi.PrepareSystem();
+            Assert.That(GetPrivateField<bool>(aoi, "_didLogMissingSystemWarning"), Is.True);
+
+            CreateColliderObject();
+            aoi.PrepareSystem();
+            Assert.That(aoi.IsSystemReady, Is.True);
+            Assert.That(GetPrivateField<bool>(aoi, "_didLogMissingSystemWarning"), Is.False);
+        }
+
+        [Test]
+        public void IsWithinBox_UsesDimensionSpecificAxes()
+        {
+            Vector3 point = new Vector3(0.5f, 50f, 0.5f);
+            Vector3 center = Vector3.zero;
+            Vector3 extents = Vector3.one;
+
+            bool result3D = InvokeIsWithinBox(point, center, extents, DimensionType.Dimension3D);
+            bool result2D = InvokeIsWithinBox(point, center, extents, DimensionType.Dimension2D);
+
+            Assert.That(result3D, Is.True);
+            Assert.That(result2D, Is.False);
+        }
+
+        [Test]
+        public void IsWithinSphere_UsesDimensionSpecificAxes()
+        {
+            Vector3 point = new Vector3(0.6f, 50f, 0.6f);
+            Vector3 center = Vector3.zero;
+
+            bool result3D = InvokeIsWithinSphere(point, center, 1f, DimensionType.Dimension3D);
+            bool result2D = InvokeIsWithinSphere(point, center, 1f, DimensionType.Dimension2D);
+
+            Assert.That(result3D, Is.True);
+            Assert.That(result2D, Is.False);
+        }
+
+        private (JobifiedGridSpatialPartitioningAOI, LiteNetLibGameManager) CreateAoiWithManager(bool isServer, ServerSceneInfo? sceneInfo)
+        {
+            GameObject managerObject = new GameObject("TestNetworkManager");
+            _createdObjects.Add(managerObject);
+            LiteNetLibGameManager manager = managerObject.AddComponent<LiteNetLibGameManager>();
+            SetAutoPropertyBackingField(manager, typeof(LiteNetLibManager.LiteNetLibManager), "IsServer", isServer);
+            SetAutoPropertyBackingField(manager, typeof(LiteNetLibGameManager), "ServerSceneInfo", sceneInfo);
+
+            GameObject aoiObject = new GameObject("TestAOI");
+            _createdObjects.Add(aoiObject);
+            JobifiedGridSpatialPartitioningAOI aoi = aoiObject.AddComponent<JobifiedGridSpatialPartitioningAOI>();
+            SetAutoPropertyBackingField(aoi, typeof(BaseInterestManager), "Manager", manager);
+            return (aoi, manager);
+        }
+
+        private GameObject CreateColliderObject()
+        {
+            GameObject colliderObject = new GameObject("TestCollider");
+            _createdObjects.Add(colliderObject);
+            colliderObject.AddComponent<BoxCollider>();
+            return colliderObject;
+        }
+
+        private GameInstance CreateGameInstance(DimensionType dimensionType)
+        {
+            GameObject gameInstanceObject = new GameObject("TestGameInstance");
+            _createdObjects.Add(gameInstanceObject);
+            GameInstance gameInstance = gameInstanceObject.AddComponent<GameInstance>();
+            SetPrivateField(gameInstance, typeof(GameInstance), "dimensionType", dimensionType);
+            return gameInstance;
+        }
+
+        private static void SetGameInstanceSingleton(GameInstance value)
+        {
+            SetStaticAutoPropertyBackingField(typeof(GameInstance), "Singleton", value);
+        }
+
+        private static void InvokeOnLoadSceneFinish(JobifiedGridSpatialPartitioningAOI aoi, bool isAdditive, bool isOnline)
+        {
+            MethodInfo method = typeof(JobifiedGridSpatialPartitioningAOI).GetMethod(
+                "OnLoadSceneFinish",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method);
+            method.Invoke(aoi, new object[] { "TestScene", isAdditive, isOnline, 1f });
+        }
+
+        private static bool InvokeIsWithinBox(Vector3 objectPosition, Vector3 center, Vector3 extents, DimensionType dimensionType)
+        {
+            MethodInfo method = typeof(JobifiedGridSpatialPartitioningAOI).GetMethod(
+                "IsWithinBox",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(Vector3), typeof(Vector3), typeof(Vector3), typeof(DimensionType) },
+                null);
+            Assert.IsNotNull(method);
+            return (bool)method.Invoke(null, new object[] { objectPosition, center, extents, dimensionType });
+        }
+
+        private static bool InvokeIsWithinSphere(Vector3 objectPosition, Vector3 center, float radius, DimensionType dimensionType)
+        {
+            MethodInfo method = typeof(JobifiedGridSpatialPartitioningAOI).GetMethod(
+                "IsWithinSphere",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(Vector3), typeof(Vector3), typeof(float), typeof(DimensionType) },
+                null);
+            Assert.IsNotNull(method);
+            return (bool)method.Invoke(null, new object[] { objectPosition, center, radius, dimensionType });
+        }
+
+        private static bool IsCellToObjectsCreated(JobifiedGridSpatialPartitioningSystem system)
+        {
+            FieldInfo fieldInfo = typeof(JobifiedGridSpatialPartitioningSystem).GetField(
+                "_cellToObjects",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(fieldInfo);
+            object map = fieldInfo.GetValue(system);
+            PropertyInfo propertyInfo = map.GetType().GetProperty("IsCreated", BindingFlags.Instance | BindingFlags.Public);
+            Assert.IsNotNull(propertyInfo);
+            return (bool)propertyInfo.GetValue(map);
+        }
+
+        private static T GetPrivateField<T>(object target, string fieldName)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(fieldInfo, $"Unable to find field `{fieldName}` on `{target.GetType().Name}`.");
+            return (T)fieldInfo.GetValue(target);
+        }
+
+        private static void SetPrivateField(object target, Type declaringType, string fieldName, object value)
+        {
+            FieldInfo fieldInfo = declaringType.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(fieldInfo, $"Unable to find field `{fieldName}`.");
+            fieldInfo.SetValue(target, value);
+        }
+
+        private static void SetAutoPropertyBackingField(object target, Type declaringType, string propertyName, object value)
+        {
+            FieldInfo fieldInfo = declaringType.GetField($"<{propertyName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(fieldInfo, $"Unable to find auto-property backing field for `{propertyName}`.");
+            fieldInfo.SetValue(target, value);
+        }
+
+        private static void SetStaticAutoPropertyBackingField(Type declaringType, string propertyName, object value)
+        {
+            FieldInfo fieldInfo = declaringType.GetField($"<{propertyName}>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(fieldInfo, $"Unable to find static auto-property backing field for `{propertyName}`.");
+            fieldInfo.SetValue(null, value);
+        }
+    }
+}

--- a/Core/Tests/EditMode/JobifiedGridSpatialPartitioningAOITests.cs.meta
+++ b/Core/Tests/EditMode/JobifiedGridSpatialPartitioningAOITests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f2e2928f4644307b5db8f14bb22f5ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Core/Tests/EditMode/MmoKitCE.Core.EditMode.Tests.asmdef
+++ b/Core/Tests/EditMode/MmoKitCE.Core.EditMode.Tests.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "MmoKitCE.Core.EditMode.Tests",
+    "references": [
+        "Assembly-CSharp"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "noEngineReferences": false
+}

--- a/Core/Tests/EditMode/MmoKitCE.Core.EditMode.Tests.asmdef.meta
+++ b/Core/Tests/EditMode/MmoKitCE.Core.EditMode.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4a3e5f26d4a49f5b936fb1e951acb64
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
PrepareSystem() requires ServerSceneInfo which isn't set until
ProceedOnlineSceneLoaded runs. On the same-scene startup path,
onLoadSceneFinish never fires, so _system stayed null and
UpdateInterestManagement silently returned — disabling all interest
management (every object visible to every player).
- Call PrepareSystem() from OnServerOnlineSceneLoaded (runs on both paths)
- Add range-based fallback with ISpatialObjectComponent support when
  _system is null (prevents silent no-op)
- Clean up stale _playerSubscribings keys via pool-and-clear each tick
- Add diagnostic logging for AOI initialization status