### PR TITLE
Refactor DirectionVector3 packing and conversion methods

### DIFF
--- a/ThirdParty/LiteNetLibManager/Scripts/PackedVariables/DirectionVector3.cs
+++ b/ThirdParty/LiteNetLibManager/Scripts/PackedVariables/DirectionVector3.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+//bad values are forced back into the safe range
+using UnityEngine;
 using LiteNetLib.Utils;
 
 namespace LiteNetLibManager
@@ -7,16 +8,27 @@ namespace LiteNetLibManager
     {
         public static implicit operator DirectionVector3(Vector3 value) => new DirectionVector3(value);
         public static implicit operator Vector3(DirectionVector3 value) => value.ToVector3();
-        public Vector3 ToVector3() => new Vector3((float)x / 100f, (float)y / 100f, (float)z / 100f);
+
+        private const float MULTIPLIER = 100f;
+        private const float INV_MULTIPLIER = 1f / MULTIPLIER;
+
+        public Vector3 ToVector3() => new Vector3(x * INV_MULTIPLIER, y * INV_MULTIPLIER, z * INV_MULTIPLIER);
+
         public sbyte x;
         public sbyte y;
         public sbyte z;
 
         public DirectionVector3(Vector3 vector3)
         {
-            x = (sbyte)(vector3.x * 100);
-            y = (sbyte)(vector3.y * 100);
-            z = (sbyte)(vector3.z * 100);
+            x = PackDirectionComponent(vector3.x);
+            y = PackDirectionComponent(vector3.y);
+            z = PackDirectionComponent(vector3.z);
+        }
+
+        private static sbyte PackDirectionComponent(float value)
+        {
+            value = Mathf.Clamp(value, -1f, 1f);
+            return (sbyte)Mathf.RoundToInt(value * MULTIPLIER);
         }
 
         public void Serialize(NetDataWriter writer)


### PR DESCRIPTION
Refactor DirectionVector3 to use multipliers for packing direction components and ensure values are clamped within a safe range.